### PR TITLE
modify max memory to use free

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -819,10 +819,11 @@ if (${memory_max_string} MATCHES "^[0-9]+")
   math(EXPR memory_in_gb "${memory_max_string} / (1024 * 1024 * 1024)")
 else()
   execute_process(
-    COMMAND bash "-c" "cat /sys/fs/cgroup/memory/memory.limit_in_bytes"
+    COMMAND bash "-c" "free | grep -o '[[:digit:]]*' | head -1"
     OUTPUT_VARIABLE memory_max_string)
+  ## memory_max_string holds the free memory in KB  
   if (${memory_max_string} MATCHES "^[0-9]+")
-    math(EXPR memory_in_gb "${memory_max_string} / (1024 * 1024 * 1024)")
+    math(EXPR memory_in_gb "${memory_max_string} / (1024 * 1024)") ## KB to GB conversion
   else()
     cmake_host_system_information(RESULT memory_max_string QUERY AVAILABLE_PHYSICAL_MEMORY )
     math(EXPR memory_in_gb "${memory_max_string} / 1024")


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
Modifies calculation of max memory in the build.

**Why were the changes made?**  
Existing use of cgroups memory limit can cause linker to incorrectly use max parallelism because linux defaults the memory limit to be the span of virtual memory rounded to page size (PAGE_COUNTER_MAX in the kernel). 

**How was the outcome achieved?**  
Modified cmake to determine physical memory from 'free'

**Additional Documentation:**  


## Approval Checklist
___Do not approve until these items are satisfied.___
- [ ] Verify the CHANGELOG has been updated, if
  - there are any NCCL API version changes,
  - any changes impact library users, and/or
  - any changes impact any other ROCm library.
